### PR TITLE
Update The_Short_List.md

### DIFF
--- a/home/The_Short_List.md
+++ b/home/The_Short_List.md
@@ -1,4 +1,4 @@
-2022-10-16
+2022-11-10
 
 The Short List - Superstar USB WiFi Adapters for Linux
 
@@ -18,6 +18,8 @@ Adapter                      Chipset / Class  / Bands       USB  WPA3  Range    
 ALFA AWUS036ACM [1] [2]      mt7612u / AC1200 / 2.4, 5      USB3  Yes  Long       Single
 
 TEROW ROW02CD [1] [2]        mt7612u / AC1200 / 2.4, 5      USB3  Yes  Long       Single
+
+Panda PAU0D                  mt7612u / AC1200 / 2.4, 5      USB3  Yes  Long       Single
 ```
 
 -----
@@ -28,6 +30,9 @@ ALFA AWUS036ACHM [1] [2] [3] mt7610u / AC600  / 2.4, 5      USB2  Yes  Very Long
 ANDDEAR MT761003             mt7610u / AC600  / 2.4, 5      USB2  Yes  Medium     Single
 
 Linksys AE6000 [1]           mt7610u / AC580  / 2.4, 5      USB2  Yes  Medium     Single
+
+Panda PAU0A                  mt7610u / AC600  / 2.4, 5      USB2  Yes  Short      Single
+
 ```
 
 -----
@@ -45,6 +50,8 @@ CHANEVE RT3572               rt3572  / N600   / 2.4, 5      USB2  Yes  Medium   
 CanaKit BC19675              rt5370  / N150   / 2.4         USB2  Yes  Short      Single
 
 Panda PAU03 [1] (nano)       rt5370  / N150   / 2.4         USB2  Yes  Short      Single
+
+Panda PAU04                  rt5370  / N150   / 2.4         USB2  Yes  Medium     Single
 
 EDUP EP-MS8551 [1] [4]       mt7601u / N150   / 2.4         USB2  Yes  Very Long  Single
 


### PR DESCRIPTION
Adding a couple of Panda adapters that I'd stand behind recommending for the short list.

Panda PAU0D is a bit cheaper and a great alternative to the ALFA AWUS036ACM.

PAU0A is a great deal on an mt7610u adapter and has been very solid for me.

And finally the PAU04 is currently only a dollar more than the PAU03 on amazon but that gets you a decently built, though a bit annoying, semi-external antenna (it is non-detachable, and only rotates 90° and 90°).

The other Panda adapters (Mini, White, PAU05, PAU06, PAU07, & PAU09) are very well built and have performed well; but unless someone needs to match a certain chipset, they are not currently a good value versus the included Panda models or other brands on the list.

I still plan on writing up reviews for some of these for the longer list, but this was a quick edit.