### PR TITLE
Fix spelling of WPA3-SAE in USB-WiFi/home/iw_list/

### DIFF
--- a/home/iw_list/ALFA_AWUS036ACHM.txt
+++ b/home/iw_list/ALFA_AWUS036ACHM.txt
@@ -268,6 +268,6 @@ hostapd.conf:
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~420 mA

--- a/home/iw_list/ALFA_AWUS036ACM.txt
+++ b/home/iw_list/ALFA_AWUS036ACM.txt
@@ -271,6 +271,6 @@ hostapd.conf:
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~380 mA

--- a/home/iw_list/COMFAST_CF-951AX.txt
+++ b/home/iw_list/COMFAST_CF-951AX.txt
@@ -668,6 +668,6 @@ vht_capab=[MAX-MPDU-11454][RXLDPC][SHORT-GI-80][TX-STBC-2BY1][RX-STBC-1][SU-BEAM
 			
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: unable to test at this time

--- a/home/iw_list/COMFAST_CF-WU785AC.txt
+++ b/home/iw_list/COMFAST_CF-WU785AC.txt
@@ -268,6 +268,6 @@ hostapd.conf:
 
 usb-modeswitch is required. This is a multi-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~380 mA

--- a/home/iw_list/DM-Digital_MT7601.txt
+++ b/home/iw_list/DM-Digital_MT7601.txt
@@ -163,6 +163,6 @@ hostapd.conf: n/a - no AP mode support
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: tbd

--- a/home/iw_list/EDUP_MS8551.txt
+++ b/home/iw_list/EDUP_MS8551.txt
@@ -163,6 +163,6 @@ hostapd.conf: n/a - no AP mode support
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: tbd

--- a/home/iw_list/LINKSYS_AE6000.txt
+++ b/home/iw_list/LINKSYS_AE6000.txt
@@ -253,6 +253,6 @@ hostapd.conf:
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~360 mA

--- a/home/iw_list/NETGEAR_A6210.txt
+++ b/home/iw_list/NETGEAR_A6210.txt
@@ -260,6 +260,6 @@ hostapd.conf:
 
 usb-modeswitch not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~420 mA

--- a/home/iw_list/TEROW_ROW02CD.txt
+++ b/home/iw_list/TEROW_ROW02CD.txt
@@ -259,6 +259,6 @@ hostapd.conf:
 
 usb-modeswitch is not required. This is a single-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~380 mA

--- a/home/iw_list/TEROW_ROW02FD.txt
+++ b/home/iw_list/TEROW_ROW02FD.txt
@@ -259,6 +259,6 @@ hostapd.conf:
 
 usb-modeswitch is required. This is a multi-state device.
 
-WPA-3 SAE: yes
+WPA3-SAE: yes
 
 Power requirement: Heavy load: ~380 mA


### PR DESCRIPTION
Fix spelling of WPA3-SAE in USB-WiFi/home/iw_list/