### PR TITLE
Remove reference to the mt7662u chipset in the file "USB WiFi Adapters that are supported with Linux in-kernel drivers"

### DIFF
--- a/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
+++ b/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
@@ -133,7 +133,7 @@ Note: Indications are that ALFA will ship products based on the mt7921au chipset
 
 -----
 
-##### ```chipset - Mediatek mt7612u and mt7662u - supported in-kernel since Linux kernel 4.19 (2018)``` - [mt7612u info](https://github.com/morrownr/7612u)
+##### ```chipset - Mediatek mt7612u - supported in-kernel since Linux kernel 4.19 (2018)``` - [mt7612u info](https://github.com/morrownr/7612u)
 
 ```
 >=====>  ALFA AWUS036ACM  <=====<


### PR DESCRIPTION
Related to https://github.com/morrownr/USB-WiFi/issues/121

Remove reference to the mt7662u chipset in the file "USB WiFi Adapters that are supported with Linux in-kernel drivers"