### PR TITLE
add markdown link check CI

### DIFF
--- a/.github/workflows/markdown-link.yml
+++ b/.github/workflows/markdown-link.yml
@@ -1,0 +1,24 @@
+name: "Markdown link CI"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+  pull_request:
+    branches: [ main ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ##   USB-WiFi main menu
 
 [![Codespell CI](https://github.com/morrownr/USB-WiFi/actions/workflows/codespell.yml/badge.svg?event=push)](https://github.com/morrownr/USB-WiFi/actions/workflows/codespell.yml)
+[![Markdown link CI](https://github.com/morrownr/USB-WiFi/actions/workflows/markdown-link.yml/badge.svg?event=push)](https://github.com/morrownr/USB-WiFi/actions/workflows/markdown-link.yml)
 
 1.  [USB WiFi adapter information for Linux](https://github.com/morrownr/USB-WiFi/blob/main/home/USB_WiFi_Adapter_Information_for_Linux.md)
 


### PR DESCRIPTION
Added a [CI](https://github.com/marketplace/actions/markdown-link-check) to check markdown files for broken links.