### PR TITLE
disable markdown link check for ebay link

### DIFF
--- a/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
+++ b/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
@@ -206,6 +206,7 @@ Rokland - 43 USD - US - [ALFA AWUS036ACM 802.11ac Dual Band USB WiFi Adapter](ht
 
 Amazon - 42 USD - US - [Alfa AWUS036ACM Long-Range Dual-Band AC1200 USB 3.0 Wi-Fi Adapter](https://www.amazon.com/Network-AWUS036ACM-Long-Range-Wide-Coverage-High-Sensitivity/dp/B08BJS8FXD)
 
+<!-- markdown-link-check-disable-next-line -->
 ebay - 40 USD - US - [Alfa AWUS036ACM 867Mbps Long Range Dual Band Wi-Fi USB Adapter](https://www.ebay.com/p/1738034359)
 
 Amazon.it - 51 EUR - Italy - [Alfa AWUS036ACM](https://www.amazon.it/Alfa-AWUS036ACM/dp/B08BJS8FXD/ref=sr_1_9?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&crid=2G6VAKKHUQXQB&keywords=mediatek+wifi+adapter&qid=1650990071&sprefix=mediatek+wifi+adapter%2Caps%2C278&sr=8-9)


### PR DESCRIPTION
Requesting page [Alfa AWUS036ACM 867Mbps Long Range Dual Band Wi-Fi USB Adapter](https://www.ebay.com/p/1738034359) returns code 0 sometimes so I disabled link checking for it. The webpage is available though when I open it in my browser.