### PR TITLE
fix broken link

### DIFF
--- a/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
+++ b/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md
@@ -548,7 +548,7 @@ Varia - 44 EUR - Germany - [AWUS036ACHM - 802.11ac WiFi USB-Adapter](https://www
 
 TUNG NETWORK TRADING - 210 RM - Malaysia - [Alfa Network AWUS036ACHM 802.11ac WiFi USB Adapter](https://www.alfa.net.my/webshaper/store/viewProd.asp?pkProductItem=83)
 
-[ALFA AWUS036ACHM Technical information](https://github.com/morrownr/USB-WiFi/blob/main/home/iw_list/ALFA_AWUS036ACHM.txt)
+[ALFA AWUS036ACHM Technical information](https://github.com/morrownr/USB-WiFi/blob/main/home/iw_list/ALFA_AWUS036ACHM_mt7610u.md)
 
 [ALFA Network Linux support for MT7610U based products](https://docs.alfa.com.tw/Support/Linux/MT7610U/)
 


### PR DESCRIPTION
Fixed a broken link where the file has been [renamed](https://github.com/morrownr/USB-WiFi/commits/main/home/iw_list/ALFA_AWUS036ACHM_mt7610u.md) but the reference has not been updated.