### PR TITLE
fix path mangled by markdown syntax

### DIFF
--- a/home/Compile_and_Install_New_RasPiOS_Kernel.md
+++ b/home/Compile_and_Install_New_RasPiOS_Kernel.md
@@ -175,7 +175,7 @@ $ sudo make modules_install
 
 $ sudo cp arch/arm64/boot/dts/broadcom/*.dtb /boot/firmware/
 
-$ sudo cp arch/arm64/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
+$ sudo cp arch/arm64/boot/dts/overlays/\*.dtb\* /boot/firmware/overlays/
 
 $ sudo cp arch/arm64/boot/dts/overlays/README /boot/firmware/overlays/
 


### PR DESCRIPTION
without this it shows as `sudo cp arch/arm64/boot/dts/overlays/.dtb /boot/firmware/overlays/`