### PR TITLE
Create Qualcomm_QCNCM865_m.2.txt

### DIFF
--- a/home/iw_list/Qualcomm_QCNCM865_m.2.txt
+++ b/home/iw_list/Qualcomm_QCNCM865_m.2.txt
@@ -1,0 +1,1180 @@
+2024-05-20
+
+Qualcomm QCNCM865 (Hamilton) WiFi 7/BT Combo Module m.2 Card
+
+Maintained by @lukejenkins
+
+
+https://www.amazon.com/dp/B0CVJPCQFJ
+
+FCC ID: J9C-QCNCM865
+
+Chipset: Qualcomm QCNCM865
+
+E Key Only
+
+
+$ lspci -vvvnn -d 17cb:1107
+08:00.0 Network controller [0280]: Qualcomm Technologies, Inc WCN785x Wi-Fi 7(802.11be) 320MHz 2x2 [FastConnect 7800] [17cb:1107] (rev 01)
+	Subsystem: Foxconn International, Inc. High Band Simultaneous Wireless Network Adapter [105b:e0f7]
+	Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
+	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort+ <TAbort- <MAbort- >SERR- <PERR- INTx-
+	Latency: 0, Cache Line Size: 64 bytes
+	Interrupt: pin ? routed to IRQ 154
+	Region 0: Memory at f7600000 (64-bit, non-prefetchable) [size=2M]
+	Capabilities: [40] Power Management version 3
+		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0+,D1-,D2-,D3hot+,D3cold+)
+		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
+	Capabilities: [50] MSI: Enable+ Count=16/32 Maskable+ 64bit-
+		Address: fee00818  Data: 0000
+		Masking: ffff8000  Pending: 00000000
+	Capabilities: [70] Express (v2) Endpoint, IntMsgNum 0
+		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s unlimited, L1 unlimited
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE+ FLReset- SlotPowerLimit 25W TEE-IO-
+		DevCtl:	CorrErr+ NonFatalErr+ FatalErr+ UnsupReq+
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop+
+			MaxPayload 128 bytes, MaxReadReq 512 bytes
+		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr+ TransPend-
+		LnkCap:	Port #0, Speed 8GT/s, Width x2, ASPM L0s L1, Exit Latency L0s <1us, L1 <64us
+			ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp+
+		LnkCtl:	ASPM L1 Enabled; RCB 64 bytes, LnkDisable- CommClk+
+			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
+		LnkSta:	Speed 8GT/s, Width x1 (downgraded)
+			TrErr- Train- SlotClk+ DLActive- BWMgmt- ABWMgmt-
+		DevCap2: Completion Timeout: Range ABCD, TimeoutDis+ NROPrPrP- LTR+
+			 10BitTagComp- 10BitTagReq- OBFF Not Supported, ExtFmt- EETLPPrefix-
+			 EmergencyPowerReduction Not Supported, EmergencyPowerReductionInit-
+			 FRS- TPHComp+ ExtTPHComp-
+			 AtomicOpsCap: 32bit- 64bit- 128bitCAS-
+		DevCtl2: Completion Timeout: 260ms to 900ms, TimeoutDis-
+			 AtomicOpsCtl: ReqEn-
+			 IDOReq- IDOCompl- LTR+ EmergencyPowerReductionReq-
+			 10BitTagReq- OBFF Disabled, EETLPPrefixBlk-
+		LnkCap2: Supported Link Speeds: 2.5-8GT/s, Crosslink- Retimer- 2Retimers- DRS-
+		LnkCtl2: Target Link Speed: 8GT/s, EnterCompliance- SpeedDis-
+			 Transmit Margin: Normal Operating Range, EnterModifiedCompliance- ComplianceSOS-
+			 Compliance Preset/De-emphasis: -6dB de-emphasis, 0dB preshoot
+		LnkSta2: Current De-emphasis Level: -6dB, EqualizationComplete+ EqualizationPhase1+
+			 EqualizationPhase2+ EqualizationPhase3+ LinkEqualizationRequest-
+			 Retimer- 2Retimers- CrosslinkRes: unsupported
+	Capabilities: [100 v2] Advanced Error Reporting
+		UESta:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
+		UEMsk:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
+		UESvrt:	DLP+ SDES+ TLP- FCP+ CmpltTO- CmpltAbrt- UnxCmplt- RxOF+ MalfTLP+ ECRC- UnsupReq- ACSViol-
+		CESta:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr-
+		CEMsk:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr+
+		AERCap:	First Error Pointer: 00, ECRCGenCap+ ECRCGenEn- ECRCChkCap+ ECRCChkEn-
+			MultHdrRecCap- MultHdrRecEn- TLPPfxPres- HdrLogCap-
+		HeaderLog: 00000000 00000000 00000000 00000000
+	Capabilities: [148 v1] Secondary PCI Express
+		LnkCtl3: LnkEquIntrruptEn- PerformEqu-
+		LaneErrStat: 0
+	Capabilities: [158 v1] Transaction Processing Hints
+		No steering table available
+	Capabilities: [1e4 v1] Latency Tolerance Reporting
+		Max snoop latency: 3145728ns
+		Max no snoop latency: 3145728ns
+	Capabilities: [1ec v1] L1 PM Substates
+		L1SubCap: PCI-PM_L1.2+ PCI-PM_L1.1+ ASPM_L1.2+ ASPM_L1.1+ L1_PM_Substates+
+			  PortCommonModeRestoreTime=70us PortTPowerOnTime=0us
+		L1SubCtl1: PCI-PM_L1.2- PCI-PM_L1.1- ASPM_L1.2- ASPM_L1.1-
+			   T_CommonMode=0us LTR1.2_Threshold=0ns
+		L1SubCtl2: T_PwrOn=44us
+	Kernel driver in use: ath12k_pci
+	Kernel modules: ath12k
+
+
+$ uname -srvmo
+Linux 6.9.1-arch1-1 #1 SMP PREEMPT_DYNAMIC Fri, 17 May 2024 16:56:38 +0000 x86_64 GNU/Linux
+
+$ iw --version
+iw version 6.7
+
+
+$ iw reg get
+global
+country US: DFS-FCC
+	(902 - 904 @ 2), (N/A, 30), (N/A)
+	(904 - 920 @ 16), (N/A, 30), (N/A)
+	(920 - 928 @ 8), (N/A, 30), (N/A)
+	(2400 - 2472 @ 40), (N/A, 30), (N/A)
+	(5150 - 5250 @ 80), (N/A, 23), (N/A), AUTO-BW
+	(5250 - 5350 @ 80), (N/A, 24), (0 ms), DFS, AUTO-BW
+	(5470 - 5730 @ 160), (N/A, 24), (0 ms), DFS
+	(5730 - 5850 @ 80), (N/A, 30), (N/A), AUTO-BW
+	(5850 - 5895 @ 40), (N/A, 27), (N/A), NO-OUTDOOR, AUTO-BW, PASSIVE-SCAN
+	(5925 - 7125 @ 320), (N/A, 12), (N/A), NO-OUTDOOR, PASSIVE-SCAN
+	(57240 - 71000 @ 2160), (N/A, 40), (N/A)
+
+phy#3 (self-managed)
+country na: DFS-UNSET
+	(2402 - 2472 @ 40), (N/A, 20), (N/A)
+	(2457 - 2482 @ 20), (N/A, 20), (N/A), PASSIVE-SCAN
+	(5170 - 5330 @ 160), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(5490 - 5730 @ 160), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(5735 - 5895 @ 160), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(5945 - 7125 @ 160), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(5945 - 7125 @ 320), (N/A, 30), (N/A), AUTO-BW, PASSIVE-SCAN
+
+
+$ iw list
+Wiphy phy3
+	wiphy index: 3
+	max # scan SSIDs: 16
+	max scan IEs length: 339 bytes
+	max # sched scan SSIDs: 0
+	max # match sets: 0
+	Retry short limit: 7
+	Retry long limit: 4
+	Coverage class: 0 (up to 0m)
+	Device supports RSN-IBSS.
+	Device supports AP-side u-APSD.
+	Supported Ciphers:
+		* TKIP (00-0f-ac:2)
+		* CCMP-128 (00-0f-ac:4)
+		* CMAC (00-0f-ac:6)
+		* CMAC-256 (00-0f-ac:13)
+		* GMAC-128 (00-0f-ac:11)
+		* GMAC-256 (00-0f-ac:12)
+		* GCMP-128 (00-0f-ac:8)
+		* GCMP-256 (00-0f-ac:9)
+		* CCMP-256 (00-0f-ac:10)
+	Available Antennas: TX 0x3 RX 0x3
+	Configured Antennas: TX 0x3 RX 0x3
+	Supported interface modes:
+		 * managed
+		 * AP
+		 * P2P-client
+		 * P2P-GO
+		 * P2P-device
+	Band 1:
+		Capabilities: 0x19e3
+			RX LDPC
+			HT20/HT40
+			Static SM Power Save
+			RX HT20 SGI
+			RX HT40 SGI
+			TX STBC
+			RX STBC 1-stream
+			Max AMSDU length: 7935 bytes
+			DSSS/CCK HT40
+		Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
+		Minimum RX AMPDU time spacing: No restriction (0x00)
+		HT TX/RX MCS rate indexes supported: 0-15
+		HE Iftypes: managed
+			HE MAC Capabilities (0x000b82100040):
+				+HTC HE Supported
+				TWT Requester
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+			HE PHY Capabilities: (0x023040890d018008020c00):
+				HE40/2.4GHz
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation: 1
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 3
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x19 0x1c 0xc7 0x71 
+		EHT Iftypes: managed
+			EHT MAC Capabilities (0x8700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe001010010360800):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Max Nc: 1
+				Tx 1024-QAM And 4096-QAM < 242-tone RU
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Support of MCS 15: 1
+			EHT MCS/NSS: (0x22222200000000000000000000):
+			EHT bw=20 MHz, max NSS for MCS 0-7: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 12-13: Rx=0, Tx=0
+		HE Iftypes: AP
+			HE MAC Capabilities (0x000f82100040):
+				+HTC HE Supported
+				TWT Requester
+				TWT Responder
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+			HE PHY Capabilities: (0x023040880d018008020c00):
+				HE40/2.4GHz
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 3
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x19 0x1c 0xc7 0x71 
+		EHT Iftypes: AP
+			EHT MAC Capabilities (0x8700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe00101001034080e):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Max Nc: 1
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Support of MCS 15: 1
+				Non-OFDMA UL MU-MIMO (80MHz)
+				Non-OFDMA UL MU-MIMO (160MHz)
+				Non-OFDMA UL MU-MIMO (320MHz)
+			EHT MCS/NSS: (0x22222200000000000000000000):
+			EHT bw=20 MHz, max NSS for MCS 0-7: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 12-13: Rx=0, Tx=0
+		HE Iftypes: mesh point
+			HE MAC Capabilities (0x000982000040):
+				+HTC HE Supported
+				Dynamic BA Fragementation Level: 1
+				OM Control
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+			HE PHY Capabilities: (0x023000800d018008000000):
+				HE40/2.4GHz
+				Device Class: 1
+				LDPC Coding in Payload
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 3
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x19 0x1c 0xc7 0x71 
+		EHT Iftypes: mesh point
+			EHT MAC Capabilities (0x8600):
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe001010010300800):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Max Nc: 1
+				Common Nominal Packet Padding: 3
+				Support of MCS 15: 1
+			EHT MCS/NSS: (0x22222200000000000000000000):
+			EHT bw=20 MHz, max NSS for MCS 0-7: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=20 MHz, max NSS for MCS 12-13: Rx=0, Tx=0
+		Bitrates (non-HT):
+			* 1.0 Mbps
+			* 2.0 Mbps (short preamble supported)
+			* 5.5 Mbps (short preamble supported)
+			* 11.0 Mbps (short preamble supported)
+			* 6.0 Mbps
+			* 9.0 Mbps
+			* 12.0 Mbps
+			* 18.0 Mbps
+			* 24.0 Mbps
+			* 36.0 Mbps
+			* 48.0 Mbps
+			* 54.0 Mbps
+		Frequencies:
+			* 2412.0 MHz [1] (20.0 dBm)
+			* 2417.0 MHz [2] (20.0 dBm)
+			* 2422.0 MHz [3] (20.0 dBm)
+			* 2427.0 MHz [4] (20.0 dBm)
+			* 2432.0 MHz [5] (20.0 dBm)
+			* 2437.0 MHz [6] (20.0 dBm)
+			* 2442.0 MHz [7] (20.0 dBm)
+			* 2447.0 MHz [8] (20.0 dBm)
+			* 2452.0 MHz [9] (20.0 dBm)
+			* 2457.0 MHz [10] (20.0 dBm)
+			* 2462.0 MHz [11] (20.0 dBm)
+			* 2467.0 MHz [12] (20.0 dBm) (no IR)
+			* 2472.0 MHz [13] (20.0 dBm) (no IR)
+			* 2484.0 MHz [14] (disabled)
+	Band 2:
+		Capabilities: 0x19e3
+			RX LDPC
+			HT20/HT40
+			Static SM Power Save
+			RX HT20 SGI
+			RX HT40 SGI
+			TX STBC
+			RX STBC 1-stream
+			Max AMSDU length: 7935 bytes
+			DSSS/CCK HT40
+		Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
+		Minimum RX AMPDU time spacing: No restriction (0x00)
+		HT TX/RX MCS rate indexes supported: 0-15
+		VHT Capabilities (0x3391f9b2):
+			Max MPDU length: 11454
+			Supported Channel Width: neither 160 nor 80+80
+			RX LDPC
+			short GI (80 MHz)
+			TX STBC
+			SU Beamformer
+			SU Beamformee
+			MU Beamformee
+			RX antenna pattern consistency
+			TX antenna pattern consistency
+		VHT RX MCS set:
+			1 streams: MCS 0-9
+			2 streams: MCS 0-9
+			3 streams: not supported
+			4 streams: not supported
+			5 streams: not supported
+			6 streams: not supported
+			7 streams: not supported
+			8 streams: not supported
+		VHT RX highest supported: 0 Mbps
+		VHT TX MCS set:
+			1 streams: MCS 0-9
+			2 streams: MCS 0-9
+			3 streams: not supported
+			4 streams: not supported
+			5 streams: not supported
+			6 streams: not supported
+			7 streams: not supported
+			8 streams: not supported
+		VHT TX highest supported: 0 Mbps
+		VHT extended NSS: not supported
+		HE Iftypes: managed
+			HE MAC Capabilities (0x000b9a100840):
+				+HTC HE Supported
+				TWT Requester
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				Maximum A-MPDU Length Exponent: 3
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+				UL 2x996-Tone RU
+			HE PHY Capabilities: (0x0c334089fd0180080e0c00):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation: 1
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				20MHz in 160/80+80MHz HE PPDU
+				80MHz in 160/80+80MHz HE PPDU
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: managed
+			EHT MAC Capabilities (0x0700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe06f090010768800):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Tx 1024-QAM And 4096-QAM < 242-tone RU
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Maximum Number Of Supported EHT-LTFs: 1
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+			EHT MCS/NSS: (0x22222222222200000000000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		HE Iftypes: AP
+			HE MAC Capabilities (0x000f9a100840):
+				+HTC HE Supported
+				TWT Requester
+				TWT Responder
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				Maximum A-MPDU Length Exponent: 3
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+				UL 2x996-Tone RU
+			HE PHY Capabilities: (0x0c334088fd0180080e0c00):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				20MHz in 160/80+80MHz HE PPDU
+				80MHz in 160/80+80MHz HE PPDU
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: AP
+			EHT MAC Capabilities (0x0700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe06f09001074880e):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Maximum Number Of Supported EHT-LTFs: 1
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+				Non-OFDMA UL MU-MIMO (80MHz)
+				Non-OFDMA UL MU-MIMO (160MHz)
+				Non-OFDMA UL MU-MIMO (320MHz)
+			EHT MCS/NSS: (0x22222222222200000000000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		HE Iftypes: mesh point
+			HE MAC Capabilities (0x00098a000040):
+				+HTC HE Supported
+				Dynamic BA Fragementation Level: 1
+				OM Control
+				Maximum A-MPDU Length Exponent: 1
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+			HE PHY Capabilities: (0x0c330080fd018008000000):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: mesh point
+			EHT MAC Capabilities (0x0600):
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe06f090010308800):
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Common Nominal Packet Padding: 3
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+			EHT MCS/NSS: (0x22222222222200000000000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		Bitrates (non-HT):
+			* 6.0 Mbps
+			* 9.0 Mbps
+			* 12.0 Mbps
+			* 18.0 Mbps
+			* 24.0 Mbps
+			* 36.0 Mbps
+			* 48.0 Mbps
+			* 54.0 Mbps
+		Frequencies:
+			* 5180.0 MHz [36] (20.0 dBm) (no IR)
+			* 5200.0 MHz [40] (20.0 dBm) (no IR)
+			* 5220.0 MHz [44] (20.0 dBm) (no IR)
+			* 5240.0 MHz [48] (20.0 dBm) (no IR)
+			* 5260.0 MHz [52] (20.0 dBm) (no IR)
+			* 5280.0 MHz [56] (20.0 dBm) (no IR)
+			* 5300.0 MHz [60] (20.0 dBm) (no IR)
+			* 5320.0 MHz [64] (20.0 dBm) (no IR)
+			* 5500.0 MHz [100] (20.0 dBm) (no IR)
+			* 5520.0 MHz [104] (20.0 dBm) (no IR)
+			* 5540.0 MHz [108] (20.0 dBm) (no IR)
+			* 5560.0 MHz [112] (20.0 dBm) (no IR)
+			* 5580.0 MHz [116] (20.0 dBm) (no IR)
+			* 5600.0 MHz [120] (20.0 dBm) (no IR)
+			* 5620.0 MHz [124] (20.0 dBm) (no IR)
+			* 5640.0 MHz [128] (20.0 dBm) (no IR)
+			* 5660.0 MHz [132] (20.0 dBm) (no IR)
+			* 5680.0 MHz [136] (20.0 dBm) (no IR)
+			* 5700.0 MHz [140] (20.0 dBm) (no IR)
+			* 5720.0 MHz [144] (20.0 dBm) (no IR)
+			* 5745.0 MHz [149] (20.0 dBm) (no IR)
+			* 5765.0 MHz [153] (20.0 dBm) (no IR)
+			* 5785.0 MHz [157] (20.0 dBm) (no IR)
+			* 5805.0 MHz [161] (20.0 dBm) (no IR)
+			* 5825.0 MHz [165] (20.0 dBm) (no IR)
+			* 5845.0 MHz [169] (20.0 dBm) (no IR)
+			* 5865.0 MHz [173] (20.0 dBm) (no IR)
+	Band 4:
+		HE Iftypes: managed
+			HE MAC Capabilities (0x000b9a100840):
+				+HTC HE Supported
+				TWT Requester
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				Maximum A-MPDU Length Exponent: 3
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+				UL 2x996-Tone RU
+			HE PHY Capabilities: (0x0c334089fd0180080e0c00):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation: 1
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				20MHz in 160/80+80MHz HE PPDU
+				80MHz in 160/80+80MHz HE PPDU
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: managed
+			EHT MAC Capabilities (0x0700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe26f090010768800):
+				320MHz in 6GHz Supported
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Tx 1024-QAM And 4096-QAM < 242-tone RU
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Maximum Number Of Supported EHT-LTFs: 1
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+			EHT MCS/NSS: (0x22222222222222222200000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		HE Iftypes: AP
+			HE MAC Capabilities (0x000f9a100840):
+				+HTC HE Supported
+				TWT Requester
+				TWT Responder
+				Dynamic BA Fragementation Level: 1
+				Broadcast TWT
+				OM Control
+				Maximum A-MPDU Length Exponent: 3
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+				UL 2x996-Tone RU
+			HE PHY Capabilities: (0x0c334088fd0180080e0c00):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				Full Bandwidth UL MU-MIMO
+				DCM Max Constellation Rx: 1
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+				20MHz in 40MHz HE PPDU 2.4GHz
+				20MHz in 160/80+80MHz HE PPDU
+				80MHz in 160/80+80MHz HE PPDU
+				TX 1024-QAM
+				RX 1024-QAM
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: AP
+			EHT MAC Capabilities (0x0700):
+				NSEP priority access Supported
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe26f09001074880e):
+				320MHz in 6GHz Supported
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Rx 1024-QAM And 4096-QAM < 242-tone RU
+				Common Nominal Packet Padding: 3
+				Maximum Number Of Supported EHT-LTFs: 1
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+				Non-OFDMA UL MU-MIMO (80MHz)
+				Non-OFDMA UL MU-MIMO (160MHz)
+				Non-OFDMA UL MU-MIMO (320MHz)
+			EHT MCS/NSS: (0x22222222222222222200000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		HE Iftypes: mesh point
+			HE MAC Capabilities (0x00098a000040):
+				+HTC HE Supported
+				Dynamic BA Fragementation Level: 1
+				OM Control
+				Maximum A-MPDU Length Exponent: 1
+				RX Control Frame to MultiBSS
+				A-MSDU in A-MPDU
+			HE PHY Capabilities: (0x0c330080fd018008000000):
+				HE40/HE80/5GHz
+				HE160/5GHz
+				Punctured Preamble RX: 3
+				Device Class: 1
+				LDPC Coding in Payload
+				SU Beamformer
+				SU Beamformee
+				Beamformee STS <= 80Mhz: 7
+				Beamformee STS > 80Mhz: 7
+				Sounding Dimensions <= 80Mhz: 1
+				PPE Threshold Present
+				Max NC: 1
+			HE RX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set <= 80 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE RX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			HE TX MCS and NSS set 160 MHz
+				1 streams: MCS 0-11
+				2 streams: MCS 0-11
+				3 streams: not supported
+				4 streams: not supported
+				5 streams: not supported
+				6 streams: not supported
+				7 streams: not supported
+				8 streams: not supported
+			PPE Threshold 0x79 0x1c 0xc7 0x71 0x1c 0xc7 0x71 
+		EHT Iftypes: mesh point
+			EHT MAC Capabilities (0x0600):
+				EHT OM Control Supported
+				Triggered TXOP Sharing Supported
+			EHT PHY Capabilities: (0xe26f090010308800):
+				320MHz in 6GHz Supported
+				SU Beamformer
+				SU Beamformee
+				Beamformee SS (80MHz): 7
+				Beamformee SS (160MHz): 3
+				Beamformee SS (320MHz): 3
+				Number Of Sounding Dimensions (80MHz): 1
+				Number Of Sounding Dimensions (160MHz): 1
+				Max Nc: 1
+				Common Nominal Packet Padding: 3
+				Support of MCS 15: 1
+				Support Of EHT DUP In 6 GHz
+			EHT MCS/NSS: (0x22222222222222222200000000):
+			EHT bw <= 80 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw <= 80 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=160 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 8-9: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 10-11: Rx=2, Tx=2
+			EHT bw=320 MHz, max NSS for MCS 12-13: Rx=2, Tx=2
+		Bitrates (non-HT):
+			* 6.0 Mbps
+			* 9.0 Mbps
+			* 12.0 Mbps
+			* 18.0 Mbps
+			* 24.0 Mbps
+			* 36.0 Mbps
+			* 48.0 Mbps
+			* 54.0 Mbps
+		Frequencies:
+			* 5955.0 MHz [1] (20.0 dBm) (no IR)
+			* 5975.0 MHz [5] (20.0 dBm) (no IR)
+			* 5995.0 MHz [9] (20.0 dBm) (no IR)
+			* 6015.0 MHz [13] (20.0 dBm) (no IR)
+			* 6035.0 MHz [17] (20.0 dBm) (no IR)
+			* 6055.0 MHz [21] (20.0 dBm) (no IR)
+			* 6075.0 MHz [25] (20.0 dBm) (no IR)
+			* 6095.0 MHz [29] (20.0 dBm) (no IR)
+			* 6115.0 MHz [33] (20.0 dBm) (no IR)
+			* 6135.0 MHz [37] (20.0 dBm) (no IR)
+			* 6155.0 MHz [41] (20.0 dBm) (no IR)
+			* 6175.0 MHz [45] (20.0 dBm) (no IR)
+			* 6195.0 MHz [49] (20.0 dBm) (no IR)
+			* 6215.0 MHz [53] (20.0 dBm) (no IR)
+			* 6235.0 MHz [57] (20.0 dBm) (no IR)
+			* 6255.0 MHz [61] (20.0 dBm) (no IR)
+			* 6275.0 MHz [65] (20.0 dBm) (no IR)
+			* 6295.0 MHz [69] (20.0 dBm) (no IR)
+			* 6315.0 MHz [73] (20.0 dBm) (no IR)
+			* 6335.0 MHz [77] (20.0 dBm) (no IR)
+			* 6355.0 MHz [81] (20.0 dBm) (no IR)
+			* 6375.0 MHz [85] (20.0 dBm) (no IR)
+			* 6395.0 MHz [89] (20.0 dBm) (no IR)
+			* 6415.0 MHz [93] (20.0 dBm) (no IR)
+			* 6435.0 MHz [97] (20.0 dBm) (no IR)
+			* 6455.0 MHz [101] (20.0 dBm) (no IR)
+			* 6475.0 MHz [105] (20.0 dBm) (no IR)
+			* 6495.0 MHz [109] (20.0 dBm) (no IR)
+			* 6515.0 MHz [113] (20.0 dBm) (no IR)
+			* 6535.0 MHz [117] (20.0 dBm) (no IR)
+			* 6555.0 MHz [121] (20.0 dBm) (no IR)
+			* 6575.0 MHz [125] (20.0 dBm) (no IR)
+			* 6595.0 MHz [129] (20.0 dBm) (no IR)
+			* 6615.0 MHz [133] (20.0 dBm) (no IR)
+			* 6635.0 MHz [137] (20.0 dBm) (no IR)
+			* 6655.0 MHz [141] (20.0 dBm) (no IR)
+			* 6675.0 MHz [145] (20.0 dBm) (no IR)
+			* 6695.0 MHz [149] (20.0 dBm) (no IR)
+			* 6715.0 MHz [153] (20.0 dBm) (no IR)
+			* 6735.0 MHz [157] (20.0 dBm) (no IR)
+			* 6755.0 MHz [161] (20.0 dBm) (no IR)
+			* 6775.0 MHz [165] (20.0 dBm) (no IR)
+			* 6795.0 MHz [169] (20.0 dBm) (no IR)
+			* 6815.0 MHz [173] (20.0 dBm) (no IR)
+			* 6835.0 MHz [177] (20.0 dBm) (no IR)
+			* 6855.0 MHz [181] (20.0 dBm) (no IR)
+			* 6875.0 MHz [185] (20.0 dBm) (no IR)
+			* 6895.0 MHz [189] (20.0 dBm) (no IR)
+			* 6915.0 MHz [193] (20.0 dBm) (no IR)
+			* 6935.0 MHz [197] (20.0 dBm) (no IR)
+			* 6955.0 MHz [201] (20.0 dBm) (no IR)
+			* 6975.0 MHz [205] (20.0 dBm) (no IR)
+			* 6995.0 MHz [209] (20.0 dBm) (no IR)
+			* 7015.0 MHz [213] (20.0 dBm) (no IR)
+			* 7035.0 MHz [217] (20.0 dBm) (no IR)
+			* 7055.0 MHz [221] (20.0 dBm) (no IR)
+			* 7075.0 MHz [225] (20.0 dBm) (no IR)
+			* 7095.0 MHz [229] (20.0 dBm) (no IR)
+			* 7115.0 MHz [233] (20.0 dBm) (no IR)
+	Supported commands:
+		 * new_interface
+		 * set_interface
+		 * new_key
+		 * start_ap
+		 * new_station
+		 * new_mpath
+		 * set_mesh_config
+		 * set_bss
+		 * authenticate
+		 * associate
+		 * deauthenticate
+		 * disassociate
+		 * join_ibss
+		 * join_mesh
+		 * remain_on_channel
+		 * set_tx_bitrate_mask
+		 * frame
+		 * frame_wait_cancel
+		 * set_wiphy_netns
+		 * set_channel
+		 * probe_client
+		 * set_noack_map
+		 * register_beacons
+		 * start_p2p_device
+		 * set_mcast_rate
+		 * connect
+		 * disconnect
+		 * channel_switch
+		 * set_qos_map
+		 * set_multicast_to_unicast
+	software interface modes (can always be added):
+		 * monitor
+	valid interface combinations:
+		 * #{ managed } <= 1, #{ AP, P2P-client, P2P-GO } <= 16, #{ P2P-device } <= 1,
+		   total <= 16, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz, 80 MHz }
+
+	HT Capability overrides:
+		 * MCS: ff ff ff ff ff ff ff ff ff ff
+		 * maximum A-MSDU length
+		 * supported channel width
+		 * short GI for 40 MHz
+		 * max A-MPDU length exponent
+		 * min MPDU start spacing
+	Device supports TX status socket option.
+	Device supports HT-IBSS.
+	Device supports SAE with AUTHENTICATE command
+	Device supports scan flush.
+	Device supports AP scan.
+	Device supports per-vif TX power setting
+	Driver supports full state transitions for AP/GO clients
+	Driver supports a userspace MPM
+	Driver/device bandwidth changes during BSS lifetime (AP/GO mode)
+	Device supports static SMPS
+	Device supports configuring vdev MAC-addr on create.
+	max # scan plans: 1
+	max scan plan interval: -1
+	max scan plan iterations: 0
+	Supported TX frame types:
+		 * IBSS: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * managed: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * AP: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * AP/VLAN: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * mesh point: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * P2P-client: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * P2P-GO: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+		 * P2P-device: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
+	Supported RX frame types:
+		 * IBSS: 0x40 0xb0 0xc0 0xd0
+		 * managed: 0x40 0xb0 0xd0
+		 * AP: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
+		 * AP/VLAN: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
+		 * mesh point: 0xb0 0xc0 0xd0
+		 * P2P-client: 0x40 0xd0
+		 * P2P-GO: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
+		 * P2P-device: 0x40 0xd0
+	Maximum associated stations in AP mode: 512
+	Supported extended features:
+		* [ RRM ]: RRM
+		* [ FILS_STA ]: STA FILS (Fast Initial Link Setup)
+		* [ CQM_RSSI_LIST ]: multiple CQM_RSSI_THOLD records
+		* [ CONTROL_PORT_OVER_NL80211 ]: control port over nl80211
+		* [ TXQS ]: FQ-CoDel-enabled intermediate TXQs
+		* [ STA_TX_PWR ]: TX power control per station
+		* [ CONTROL_PORT_NO_PREAUTH ]: disable pre-auth over nl80211 control port support
+		* [ SCAN_FREQ_KHZ ]: scan on kHz frequency support
+		* [ CONTROL_PORT_OVER_NL80211_TX_STATUS ]: tx status for nl80211 control port support
+		* [ FILS_DISCOVERY ]: FILS discovery frame transmission support
+		* [ UNSOL_BCAST_PROBE_RESP ]: unsolicated broadcast probe response transmission support
+		* [ POWERED_ADDR_CHANGE ]: can change MAC address while up
+		* [ PUNCT ]: preamble puncturing in AP mode


### PR DESCRIPTION
The linux driver for this chip is very actively being worked on. Last week with a 6.8 kernel, it wasn't working. Today after upgrading to a 6.9 kernel (and the latest arch firmware bundle), it is working!

I'm not quite sure how the regulatory is handled with the ath12k driver. It is self-managed, but it doesn't seem to update based on a scan like the intel chips do.