### PR TITLE
USB_WiFi_Chipsets.md clarify USB version of Mediatek MT7925

### DIFF
--- a/home/USB_WiFi_Chipsets.md
+++ b/home/USB_WiFi_Chipsets.md
@@ -10,7 +10,7 @@ the quality of the amp and whether the device requires mode switching and so on.
 | Chipset           | Interface | Standard | Maximum<br>Channel<br>Width   | Linux<br>In-Kernel<br>Driver | AP Mode        | Monitor Mode   | Recommended<br>For<br>Linux |
 |:------------------:|-----------|----------|:-----:|:----------------------------:|:----------------:|:----------------:|:-----------------:|
 Mediatek MT7927   | USB3      | WiFi 7  |  320   | pending       |  |  |  |
-Mediatek MT7925   | USB3      | WiFi 7  |  160   |:heavy_check_mark: 6.7+       |:heavy_check_mark:|:heavy_check_mark:| Yes [4] |
+Mediatek MT7925u  | USB3      | WiFi 7  |  160   |:heavy_check_mark: 6.7+       |:heavy_check_mark:|:heavy_check_mark:| Yes [4] |
 Realtek RTL8852cu | ?     | WiFi 6E  |  160  |:x: [6]                       |                  |                  | No  |
 Realtek RTL8832cu | USB3      | WiFi 6E  |  160  |:x:                           |                  |                  | No  |
 Mediatek MT7921au | USB3      | WiFi 6E  |   80  |:heavy_check_mark: 5.18+      |:heavy_check_mark:|:heavy_check_mark:| Yes |


### PR DESCRIPTION
The Mediatek MT7925 is available as both PCie+USB versions (MT7925e - where the wifi interface is PCIe and the Bluetooth is USB), and USB-only (MT7925u).  Previously the variant wasn't specified.