### PR TITLE
doc: Use a broader search key for `RestartSec=`

### DIFF
--- a/home/AP_Mode/Bridged_Wireless_Access_Point.md
+++ b/home/AP_Mode/Bridged_Wireless_Access_Point.md
@@ -621,7 +621,7 @@ Add the Environment=DAEMON_OPTS= line as shown below (remember to change <your_h
 Environment=DAEMON_OPTS="-d -K -f /home/<your_home>/hostapd.log"
 ```
 
-Change RestartSec=0 line as shown below
+Change RestartSec= line as shown below
 
 ```
 RestartSec=3


### PR DESCRIPTION
Because as of `hostapd` `2.10-22` (Oracular) the value coming from copying the packaged `/usr/lib/systemd/system/hostapd.service` is already `RestartSec=2`.