### PR TITLE
add Baseus BA04 bluetooth adapter

### DIFF
--- a/home/Recommended_Bluetooth_Adapters_for_Linux.md
+++ b/home/Recommended_Bluetooth_Adapters_for_Linux.md
@@ -14,6 +14,7 @@ in Issues.
 | Adapter                           | Chipset   | Version | Price     | Link                                      |
 |-----------------------------------|-----------|---------|-----------|-------------------------------------------|
 | EDUP EP-B3536 [1]                 | rtl8761BU | 5.1     | 10 USD    | https://www.amazon.com/dp/B09KG7QQ5V      |
+| Baseus BA04                       | rtl8761BU | 5.1     | 12 USD    | aliexpress.com/item/1005005187191049.html |
 
 
 [1] I have first hand experience with this adapter.


### PR DESCRIPTION
Works fine. Device pairing works, game controllers work, headsets work and I was able to connect up to 3 devices


And here are some details about it:
```
usb 1-1: new full-speed USB device number 29 using xhci_hcd
usb 1-1: New USB device found, idVendor=0bda, idProduct=8771, bcdDevice= 2.00
usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
usb 1-1: Product: Bluetooth Radio
usb 1-1: Manufacturer: Realtek
usb 1-1: SerialNumber: <REDACTED>
Bluetooth: hci1: RTL: examining hci_ver=0a hci_rev=000b lmp_ver=0a lmp_subver=8761
Bluetooth: hci1: RTL: rom_version status=0 version=1
Bluetooth: hci1: RTL: loading rtl_bt/rtl8761bu_fw.bin
Bluetooth: hci1: RTL: loading rtl_bt/rtl8761bu_config.bin
Bluetooth: hci1: RTL: cfg_sz 6, total sz 30210
Bluetooth: hci1: RTL: fw version 0xdfc6d922
Bluetooth: MGMT ver 1.23
```

Tested under Linux 6.12