### PR TITLE
doc: Deduplicate `hostapd` arguments

### DIFF
--- a/home/AP_Mode/Bridged_Wireless_Access_Point.md
+++ b/home/AP_Mode/Bridged_Wireless_Access_Point.md
@@ -653,7 +653,7 @@ ExecStartPre=/bin/sleep 6
 Change the ExecStart= line as shown below
 
 ```
-ExecStart=/usr/sbin/hostapd -B -P /run/hostapd.pid -B $DAEMON_OPTS $DAEMON_CONF
+ExecStart=/usr/sbin/hostapd -B -P /run/hostapd.pid $DAEMON_OPTS $DAEMON_CONF
 ```
 
 Select one of the following options.


### PR DESCRIPTION
It is superfluous to provide `-B` more than once.