### PR TITLE
Nonexistent option

### DIFF
--- a/home/AP_Mode/Bridged_Wireless_Access_Point.md
+++ b/home/AP_Mode/Bridged_Wireless_Access_Point.md
@@ -653,7 +653,7 @@ ExecStartPre=/bin/sleep 6
 Change the ExecStart= line as shown below
 
 ```
-ExecStart=/usr/sbin/hostapd -B -P /run/hostapd.pid -B $DAEMON_OPTS $DAEMON_CONF
+ExecStart=/usr/sbin/hostapd -B -P /run/hostapd.pid $DAEMON_OPTS $DAEMON_CONF
 ```
 
 Select one of the following options.

--- a/home/AP_Mode/hostapd-WiFi7.conf
+++ b/home/AP_Mode/hostapd-WiFi7.conf
@@ -127,7 +127,6 @@ ieee80211w=2
 # IEEE 802.11n (WiFi 4) configuration
 ieee80211n=1
 wmm_enabled=1
-ht_coex=0
 #
 # generic setting - 20 MHz channel width
 #ht_capab=[SHORT-GI-20]


### PR DESCRIPTION
   The `hostapd-WiFi7.conf` at line 12 rightfully instructs users
    to compile hostapd and the `Upgrade_hostapd.md` to get the sources
    from git://w1.fi/srv/git/hostap.git.
    After inspecting these sources, it becomes evident that
    `ht_coex` is a non-exisitent option in the upstream repo
    and trying to start a compiled `hostapd` with this config option,
    will fail for the very same reason.
    Further investigation suggests, that the patch that does make,
    `ht_coex` available has been made by Felix Fietkau
    and it is only included in a few downstream packages like OpenWrt.
    Furthermore inspecting the patch reveals that `ht_coex=0` setting is
    logically equivalent of not having the patch at all,
    hence the suggestion here is to simply remove this option from the config file.
    Instead of patching the upstream repo for no real benefit.